### PR TITLE
better debugging: mod settings, gui, fastfowarding

### DIFF
--- a/AnyPctTAS_0.2.2/control.lua
+++ b/AnyPctTAS_0.2.2/control.lua
@@ -520,36 +520,37 @@ script.on_event(
         local player = game.players[event.player_index]
 		local pos = player.position
 
-		-- this and button style is copied from redmew
+		-- this guard and button style is copied from redmew
         if not player or not player.valid then
             return
         end
 		
+		-- create tas debug gui if it is not disabled
 		if settings.global["tas-gui-debug"].value ~= "disabled" then
 			local t = 
 				player.gui.top.add {
 				type = 'label',
 				name = "tas_debug_gui_time",
-				caption = ""
+				caption = "0"
 			}
 			local p = 
 				player.gui.top.add {
 				type = 'label',
 				name = "tas_debug_gui_pos",
-				caption = ""
+				caption = string.format("(%.2f, %.2f)", 0.0, 0.0)
 			}
 			local s = 
 				player.gui.top.add {
 				type = 'label',
 				name = "tas_debug_gui_state",
-				caption = ""
+				caption = string.format("%d %s", 1, task[1][1])
 			}
 
 			local b =
 				player.gui.top.add {
 				type = 'button',
 				name = "tas_debug_gui_toggle",
-				caption = '>',
+				caption = '<',
 			}
 			local style = b.style
 			style.width = 18
@@ -559,12 +560,12 @@ script.on_event(
 			style.right_padding = 0
 			style.bottom_padding = 0
 			style.font = 'default-small-bold'
-			-- start with gui open
-			if settings.global["tas-gui-debug"].value == "open" then
-				t.caption = "0"
-				p.caption = string.format("(%.2f, %.2f)", 0.0, 0.0)
-				s.caption = string.format("%d %s", 1, task[1][1])
-				b.caption = "<"
+			-- make gui invisible depending on mod settings
+			if settings.global["tas-gui-debug"].value == "closed" then
+				t.visible = false
+				p.visible = false
+				s.visible = false
+				b.caption = ">"
 			end
 		end
     end
@@ -580,15 +581,17 @@ script.on_event(
 			local top = player.gui.top
 
 			if button.caption == '<' then
-				-- closes debug info by displaying nothing
-				top.children[2].caption = ""
-				top.children[3].caption = ""
-				top.children[4].caption = ""
+				-- close gui
+				-- idk what is children[1]; last child is toggle button, which shouldn't be disabled
+				for i = 2, #top.children - 1 do
+					top.children[i].visible = false
+				end
 				button.caption = '>'
 			else
-				top.children[2].caption = event.tick
-				top.children[3].caption = string.format("(%.2f, %.2f)", pos.x, pos.y)
-				top.children[4].caption = string.format("%d %s", state, task[state][1])
+				-- open gui
+				for i = 2, #top.children - 1 do
+					top.children[i].visible = true
+				end
 				button.caption = '<'
 			end
 		end
@@ -603,11 +606,9 @@ script.on_event(defines.events.on_tick, function(event)
 
 	-- update debug gui every tick
 	if settings.global["tas-gui-debug"].value ~= "disabled" then
-		if top.children[5].caption == "<" then
-			top.children[2].caption = event.tick
-			top.children[3].caption = string.format("(%.2f, %.2f)", pos.x, pos.y)
-			top.children[4].caption = string.format("%d %s", state, task[state][1])
-		end
+		top.children[2].caption = event.tick
+		top.children[3].caption = string.format("(%.2f, %.2f)", pos.x, pos.y)
+		top.children[4].caption = string.format("%d %s", state, task[state][1])
 	end
 
 	-- set gamespeed to default, stopping fastfowarding, if we reach target state

--- a/AnyPctTAS_0.2.2/control.lua
+++ b/AnyPctTAS_0.2.2/control.lua
@@ -546,6 +546,21 @@ script.on_event(
 				caption = string.format("%d %s", 1, task[1][1])
 			}
 
+			local pause_button = 
+				player.gui.top.add {
+				type = 'button',
+				name = "tas_debug_gui_pause",
+				caption = 'P',
+			}
+			-- TODO: remove redundancy / verbosity?
+			local style = pause_button.style
+			style.width = 18
+			style.height = 18
+			style.left_padding = 0
+			style.top_padding = 0
+			style.right_padding = 0
+			style.bottom_padding = 0
+			style.font = 'default-small-bold'
 			local b =
 				player.gui.top.add {
 				type = 'button',
@@ -565,6 +580,7 @@ script.on_event(
 				t.visible = false
 				p.visible = false
 				s.visible = false
+				pause_button.visible = false
 				b.caption = ">"
 			end
 		end
@@ -594,6 +610,8 @@ script.on_event(
 				end
 				button.caption = '<'
 			end
+		elseif event.element.name == "tas_debug_gui_pause" then
+			game.tick_paused = not game.tick_paused
 		end
     end
 )

--- a/AnyPctTAS_0.2.2/control.lua
+++ b/AnyPctTAS_0.2.2/control.lua
@@ -664,7 +664,7 @@ script.on_event(defines.events.on_tick, function(event)
 		top.children[2].caption = event.tick
 		top.children[3].caption = string.format("(%.2f, %.2f)", pos.x, pos.y)
 		if task[state] ~= nil then
-		top.children[4].caption = string.format("%d %s", state, task[state][1])
+			top.children[4].caption = string.format("%d %s", state, task[state][1])
 		else
 			top.children[4].caption = ""
 		end

--- a/AnyPctTAS_0.2.2/control.lua
+++ b/AnyPctTAS_0.2.2/control.lua
@@ -626,7 +626,11 @@ script.on_event(defines.events.on_tick, function(event)
 	if settings.global["tas-gui-debug"].value ~= "disabled" then
 		top.children[2].caption = event.tick
 		top.children[3].caption = string.format("(%.2f, %.2f)", pos.x, pos.y)
+		if task[state] ~= nil then
 		top.children[4].caption = string.format("%d %s", state, task[state][1])
+		else
+			top.children[4].caption = ""
+		end
 	end
 
 	-- set gamespeed to default, stopping fastfowarding, if we reach target state

--- a/AnyPctTAS_0.2.2/locale/en/locale.cfg
+++ b/AnyPctTAS_0.2.2/locale/en/locale.cfg
@@ -1,0 +1,13 @@
+[mod-setting-name]
+tas-console-debug=Console debug
+tas-gui-debug=Debug gui
+tas-target-task=Target task
+tas-max-speed=Max speed
+tas-default-speed=Default speed
+
+[mod-setting-description]
+tas-console-debug=Print various debug info in console
+tas-gui-debug=Displays time (ticks), player position, and current task; open - gui is open by default; close - gui is closed by default; disabled - even the toggle button is disabled
+tas-target-task=Target task number to fastfoward to
+tas-max-speed=Game speed when fastfowarding to target task
+tas-default-speed=Normal game speed when not fastfowarding

--- a/AnyPctTAS_0.2.2/settings.lua
+++ b/AnyPctTAS_0.2.2/settings.lua
@@ -1,0 +1,28 @@
+data:extend({{
+        type = "bool-setting",
+        name = "tas-console-debug",
+        setting_type = "runtime-global",
+        default_value = false
+    }, {
+        type = "string-setting",
+        name = "tas-gui-debug",
+        setting_type = "runtime-global",
+        default_value = "disabled",
+        allowed_values = {"open", "close", "disabled"}
+    }, {
+        type = "int-setting",
+        name = "tas-target-task",
+        setting_type = "runtime-global",
+        default_value = 0
+    }, {
+        type = "double-setting",
+        name = "tas-max-speed",
+        setting_type = "runtime-global",
+        default_value = 1000.0
+    }, {
+        type = "double-setting",
+        name = "tas-default-speed",
+        setting_type = "runtime-global",
+        default_value = 1.0
+    }
+})

--- a/AnyPctTAS_0.2.2/settings.lua
+++ b/AnyPctTAS_0.2.2/settings.lua
@@ -8,7 +8,7 @@ data:extend({{
         name = "tas-gui-debug",
         setting_type = "runtime-global",
         default_value = "disabled",
-        allowed_values = {"open", "close", "disabled"}
+        allowed_values = {"open", "closed", "disabled"}
     }, {
         type = "int-setting",
         name = "tas-target-task",

--- a/AnyPctTAS_0.2.2/tasks.lua
+++ b/AnyPctTAS_0.2.2/tasks.lua
@@ -1,7 +1,8 @@
 local task = {}
 
 task[1] = {"move", {0.0,0.0}}
-task[2] = {"speed", 1}
+--task[2] = {"speed", settings.global["tas-max-speed"].value}
+task[2] = {"move", {0.0,0.0}}
 task[3] = {"craft", 3, "iron-gear-wheel"}
 task[4] = {"idle", 1}
 task[5] = {"walk", {6.6,75.8}}


### PR DESCRIPTION
This probably should've been separated into few smaller commits, but hopefully it's still readable.

We start using mod settings, so we can change things (enable debug, fastfoward to another task) without tabbing out of the game and edit source files. Perhaps in the future we can make it so that these settings can be changed within a run using a gui or something.
This change adds the files `locale.cfg` and `settings.lua`.

We use a simple gui to display the debug information (player pos, tick#, state / task), so the console isn't being spammed every tick.
The gui can be entirely disabled with mod settings, so the game will look identical to vanilla, which should be helpful when recording for youtube or something.
However, this means we can only look at the information of the current tick, and can't look back at the info of previous ticks. If this is a problem, we can add a new mod setting to re-enable printing these debug info in the console. Probably change `tas-console-debug` into a `string-setting` with multiple `allowed-values` instead.

I added in mod settings to allow for fastfowarding to a certain task. If we want to fastfoward to a certain task (`tas-target-task` > 0), the game starts at `tas-max-speed` (instead of 1), and the gamespeed is reset to `tas-default-speed` if `tas-target-task` is running.
Hopefully this eliminates the need for the `speed` task.